### PR TITLE
Updating Entity Framework dependencies

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Before beginning work please read [the guide](CONTRIBUTING.md). For questions, c
 [![Signal Processing label](src/RapidField.SolidInstruments.SignalProcessing/Label.SignalProcessing.300w.png)](src/RapidField.SolidInstruments.SignalProcessing/README.md)
 [![Text Encoding label](src/RapidField.SolidInstruments.TextEncoding/Label.TextEncoding.300w.png)](src/RapidField.SolidInstruments.TextEncoding/README.md)
 
+## Releases
+- - -
+
+#### Preview
+
+| Version         | Notes                               | Branch                                                                                       |
+| :-------------- | :---------------------------------- | :------------------------------------------------------------------------------------------- |
+| 1.0.23-preview1 | [Read](doc/releasenotes/v1.0.23.md) | [Explore](https://www.github.com/RapidField/solid-instruments/tree/release/v1.0.23-preview1) |
 - - -
 <br />
 

--- a/README.md
+++ b/README.md
@@ -34,7 +34,6 @@ Before beginning work please read [the guide](CONTRIBUTING.md). For questions, c
 [![Text Encoding label](src/RapidField.SolidInstruments.TextEncoding/Label.TextEncoding.300w.png)](src/RapidField.SolidInstruments.TextEncoding/README.md)
 
 ## Releases
-- - -
 
 #### Preview
 

--- a/doc/index.md
+++ b/doc/index.md
@@ -35,6 +35,6 @@ Solid Instruments is a collection of free, open-source .NET libraries. It was cr
 
 #### Preview
 
-| Version         | GitHub branch                                                                               | Release notes                   |
-| :-------------- | :------------------------------------------------------------------------------------------ | :------------------------------ |
-| 1.0.23-preview1 | [Explore](https://www.github.com/RapidField/solid-instruments/tree/release/1.0.23-preview1) | [Read](releasenotes/v1.0.23.md) |
+| Version         | Notes                           | Branch                                                                                       |
+| :-------------- | :------------------------------ | :------------------------------------------------------------------------------------------- |
+| 1.0.23-preview1 | [Read](releasenotes/v1.0.23.md) | [Explore](https://www.github.com/RapidField/solid-instruments/tree/release/v1.0.23-preview1) |

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -38,7 +38,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.4">

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -39,7 +39,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6">
             <PrivateAssets>all</PrivateAssets>

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -41,7 +41,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.4">
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Tools" Version="2.2.6">
             <PrivateAssets>all</PrivateAssets>
             <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
         </PackageReference>

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -36,7 +36,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
     </ItemGroup>
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -35,7 +35,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
         <Content Include="..\..\LICENSE.txt" Link="LICENSE.txt" Pack="true" PackagePath="" />
     </ItemGroup>
     <ItemGroup>
-        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />

--- a/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
+++ b/src/RapidField.SolidInstruments.DataAccess.EntityFramework/RapidField.SolidInstruments.DataAccess.EntityFramework.csproj
@@ -37,7 +37,7 @@ Copyright (c) RapidField LLC. Licensed under the MIT License. See LICENSE.txt in
     <ItemGroup>
         <PackageReference Include="Microsoft.EntityFrameworkCore" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Design" Version="2.2.4" />
-        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.4" />
+        <PackageReference Include="Microsoft.EntityFrameworkCore.InMemory" Version="2.2.6" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.Relational" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer" Version="2.2.4" />
         <PackageReference Include="Microsoft.EntityFrameworkCore.SqlServer.Design" Version="2.0.0-preview1-final" />


### PR DESCRIPTION
## Pull Request

### Overview

Here is an overview of the changes that were made.

1. Fixing a minor styling issue on README.md.
2. Bump Microsoft.EntityFrameworkCore from 2.2.4 to 2.2.6
3. Bump Microsoft.EntityFrameworkCore.SqlServer from 2.2.4 to 2.2.6
4. Bump Microsoft.EntityFrameworkCore.Design from 2.2.4 to 2.2.6
5. Bump Microsoft.EntityFrameworkCore.Tools from 2.2.4 to 2.2.6
6. Bump Microsoft.EntityFrameworkCore.Relational from 2.2.4 to 2.2.6
7. Bump Microsoft.EntityFrameworkCore.InMemory from 2.2.4 to 2.2.6

### Readiness Checklist

This pull request is in compliance with the readiness requirements listed below.

- [ ] This pull request addresses one or more existing issues.
- [x] Commit messages are simple and informative, and include references to an issue number.
- [x] Applicable unit tests have been added or updated.
- [x] All unit tests are passing.
- [x] Thorough source documentation accompanies all code additions and modifications.
- [x] Styling guidelines were followed.
